### PR TITLE
Fix crash when function accepts both &self and a generic parameter by reference

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -134,14 +134,15 @@ fn transform_sig(sig: &mut Signature, args: &RecursionArgs) {
         requires_lifetime = true;
     }
 
-    // If our function accepts &self, then we modify this to the explicit lifetime &'life0 self,
-    // and add the bound &'life0 : 'async_recursion
+    // If our function accepts &self, then we modify this to the explicit lifetime &'life_self,
+    // and add the bound &'life_self : 'async_recursion
     if let Some(slt) = self_lifetime {
         let lt = {
             if let Some(lt) = slt.as_mut() {
                 lt.clone()
             } else {
-                let lt: Lifetime = parse_quote!('life0);
+                // We use `life_self here to avoid any collisions with `life0, `life1 from above
+                let lt: Lifetime = parse_quote!('life_self);
                 sig.generics.params.push(parse_quote!(#lt));
 
                 // add lt to the lifetime of self

--- a/tests/struct_methods.rs
+++ b/tests/struct_methods.rs
@@ -1,7 +1,7 @@
 use async_recursion::async_recursion;
 use futures_executor::block_on;
 
-struct Empty {}
+pub struct Empty {}
 
 impl Empty {
     #[async_recursion]
@@ -27,6 +27,22 @@ impl Empty {
     pub async fn generic_parameter<T>(&self, _something: &T) -> u64 {
         0
     }
+
+    #[async_recursion]
+    pub async fn all_of_the_above<'a, 'b, S, T>(
+        &self,
+        // Some references with / without lifetimes to generic parameters
+        _x: &S,
+        _y: &'b T,
+        // Some generic parameters passed by value
+        _w: S,
+        _z: T,
+        // A reference to a concrete type without a lifetime
+        _p: &usize,
+        // A reference to a concrete type with a lifetime
+        _q: &'a u64,
+    ) {
+    }
 }
 
 #[test]
@@ -46,4 +62,15 @@ fn struct_method_empty_string_works() {
         assert_eq!(e.empty_string("hello world").await, "");
         assert_eq!(e.empty_string("something else").await, "");
     });
+}
+
+#[test]
+fn struct_method_with_generic_parameter_works() {
+    block_on(async move {
+        let e = Empty {};
+        assert_eq!(
+            e.generic_parameter::<*const u64>(&(0 as *const u64)).await,
+            0
+        );
+    })
 }

--- a/tests/struct_methods.rs
+++ b/tests/struct_methods.rs
@@ -22,6 +22,11 @@ impl Empty {
             self.empty_string(&some_str[1..]).await
         }
     }
+
+    #[async_recursion]
+    pub async fn generic_parameter<T>(&self, _something: &T) -> u64 {
+        0
+    }
 }
 
 #[test]


### PR DESCRIPTION
Fixes #7. 