### PR TITLE
fix(docs): Add missing word in comment (follow-up to #30)

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -63,7 +63,7 @@ fn transform_sig(sig: &mut Signature, args: &RecursionArgs) {
         if let FnArg::Typed(pt) = arg {
             match pt.ty.as_mut() {
                 // rustc can give us a None-delimited group if this type comes from
-                // a macro_rules macro.  I don't this can happen for code the user has written.
+                // a macro_rules macro.  I don't think this can happen for code the user has written.
                 Type::Group(tg) => {
                     if let Type::Reference(tr) = &mut *tg.elem {
                         ref_arguments.push(tr);


### PR DESCRIPTION
This is a quite irrelevant PR, but I thought I'd fix it anyway.

A word is missing in a comment introduced in 833b0219b3c1d5e7f86d83a3e4389bc3f7a1a5e6.
This PR adds the missing word (guessing what might have been meant by the author).