### PR TITLE
Sync bound

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -184,6 +184,12 @@ fn transform_sig(sig: &mut Signature, args: &RecursionArgs) {
         quote!()
     };
 
+    let sync_bound: TokenStream = if args.sync_bound {
+        quote!(+ ::core::marker::Sync)
+    } else {
+        quote!()
+    };
+
     let where_clause = sig
         .generics
         .where_clause
@@ -207,6 +213,6 @@ fn transform_sig(sig: &mut Signature, args: &RecursionArgs) {
     // Modify the return type
     sig.output = parse_quote! {
         -> ::core::pin::Pin<Box<
-            dyn ::core::future::Future<Output = #ret> #box_lifetime #send_bound >>
+            dyn ::core::future::Future<Output = #ret> #box_lifetime #send_bound #sync_bound >>
     };
 }

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -1,0 +1,21 @@
+use std::future::pending;
+
+use async_recursion::async_recursion;
+
+
+#[async_recursion(Sync)]
+async fn send_plus_sync() {
+    pending::<()>().await;
+
+}
+
+#[async_recursion(?Send Sync)]
+async fn only_sync() {
+    pending::<()>().await;
+}
+
+#[async_recursion(?Send)]
+async fn neither() {
+    pending::<()>().await;
+
+}


### PR DESCRIPTION
```rust

pub type FutSet<'f> =
    FuturesUnordered<Pin<Box<dyn Future<Output = Result<()>> + marker::Send + Sync + 'f>>>;

assert_impl_all!(FutSet: marker::Send, Sync);

impl Listener {
    // #[async_recursion]
    // async fn sock_accept(sock: UnixListener, set: &FutSet) -> Result<()> {
    //     if let Result::Ok((ux, _anon)) = sock.accept().await {
    //         let fds = ux.recv_stream().await?;
    //         let f: Framed<UnixStream, LengthDelimitedCodec> =
    //             Framed::new(ux, LengthDelimitedCodec::new());
    //         let f = FramedUS(f);
    //         let mut k = Server(f, FDStream(fds));
    //         let id = try_session(
    //             &mut k,
    //             async move |proto: <SubIdentify<'_, Client> as PartialDual<
    //                 '_,
    //                 Client,
    //                 Server,
    //             >>::Dual<End<'_, _>>| { proto.receive().await },
    //         )
    //         .await?;
    //         set.push(Self::sock_accept(sock, set))
    //     }
    //     Ok(())
    // }
    fn sock_accept<'life0, 'async_recursion>(
        sock: UnixListener,
        set: &'life0 FutSet,
    ) -> ::core::pin::Pin<
        Box<dyn ::core::future::Future<Output = Result<()>> + 'async_recursion + ::core::marker::Send + Sync>,
    >
    where
        'life0: 'async_recursion,
    {
        Box::pin(async move {
            if let Result::Ok((ux, _anon)) = sock.accept().await {
                let fds = ux.recv_stream().await?;
                let f: Framed<UnixStream, LengthDelimitedCodec> =
                    Framed::new(ux, LengthDelimitedCodec::new());
                let f = FramedUS(f);
                let mut k = Server(f, FDStream(fds));
                let id = try_session(
                    &mut k,
                    async move |proto: <SubIdentify<'_, Client> as PartialDual<
                        '_,
                        Client,
                        Server,
                    >>::Dual<End<'_, _>>| { proto.receive().await },
                )
                .await?;
                set.push(Self::sock_accept(sock, set))
            }
            Ok(())
        })
    }
```

I came across the above use case in my project. It requires Sync.