### PR TITLE
Add support for `Sync` argument

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rust-src  # required for consistent error messages
       - run: cargo install cargo-expand
       - run: cargo test --verbose
 

--- a/README.md
+++ b/README.md
@@ -52,25 +52,35 @@ async fn fib(n : u32) -> u32 {
 }
 ```
 
-## ?Send Option
+## ?Send option
 
-The returned future has a `Send` bound to make sure it can be sent between threads.
+The returned `Future` has a `Send` bound to make sure it can be sent between threads.
 If this is undesirable you can mark that the bound should be left out like so:
 
 ```rust
 #[async_recursion(?Send)]
-async fn example() {
+async fn returned_future_is_not_send() {
+   // ...
+}
+```
+
+## Sync option
+
+The returned `Future` doesn't have a `Sync` bound as it is usually not required. 
+You can include a `Sync` bound as follows:
+
+```rust
+#[async_recursion(Sync)]
+async fn returned_future_is_sync() {
    // ...
 }
 ```
 
 In detail:
 
-- `#[async_recursion]` modifies your function to return a [`BoxFuture`], and
-- `#[async_recursion(?Send)]` modifies your function to return a [`LocalBoxFuture`].
-
-[`BoxFuture`]: https://docs.rs/futures/0.3.19/futures/future/type.BoxFuture.html
-[`LocalBoxFuture`]: https://docs.rs/futures/0.3.19/futures/future/type.LocalBoxFuture.html
+- `#[async_recursion]` modifies your function to return a boxed `Future` with a `Send` bound.
+- `#[async_recursion(?Send)]` modifies your function to return a boxed `Future` _without_ a `Send` bound.
+- `#[async_recursion(Sync)]` modifies your function to return a boxed `Future` with a `Send` and `Sync` bound.
 
 ### License
 

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -173,6 +173,12 @@ fn transform_sig(sig: &mut Signature, args: &RecursionArgs) {
         quote!()
     };
 
+    let sync_bound: TokenStream = if args.sync_bound {
+        quote!(+ ::core::marker::Sync)
+    } else {
+        quote!()
+    };
+
     let where_clause = sig
         .generics
         .where_clause
@@ -196,6 +202,6 @@ fn transform_sig(sig: &mut Signature, args: &RecursionArgs) {
     // Modify the return type
     sig.output = parse_quote! {
         -> ::core::pin::Pin<Box<
-            dyn ::core::future::Future<Output = #ret> #box_lifetime #send_bound >>
+            dyn ::core::future::Future<Output = #ret> #box_lifetime #send_bound #sync_bound>>
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,27 +52,40 @@
 //! }
 //! ```
 //!
-//! ## ?Send Option
+//! ## ?Send option
 //!
-//! The returned future has a [`Send`] bound to make sure it can be sent between threads.
+//! The returned [`Future`] has a [`Send`] bound to make sure it can be sent between threads.
 //! If this is undesirable you can mark that the bound should be left out like so:
 //!
 //! ```rust
 //! # use async_recursion::async_recursion;
 //!
 //! #[async_recursion(?Send)]
-//! async fn example() {
+//! async fn returned_future_is_not_send() {
+//!     // ...
+//! }
+//! ```
+//!
+//! ## Sync option
+//!
+//! The returned [`Future`] doesn't have a [`Sync`] bound as it is usually not required.
+//! You can include a [`Sync`] bound as follows:
+//!
+//! ```rust
+//! # use async_recursion::async_recursion;
+//!
+//! #[async_recursion(Sync)]
+//! async fn returned_future_is_send_and_sync() {
 //!     // ...
 //! }
 //! ```
 //!
 //! In detail:
 //!
-//! - `#[async_recursion]` modifies your function to return a [`BoxFuture`], and
-//! - `#[async_recursion(?Send)]` modifies your function to return a [`LocalBoxFuture`].
 //!
-//! [`BoxFuture`]: https://docs.rs/futures/0.3.19/futures/future/type.BoxFuture.html
-//! [`LocalBoxFuture`]: https://docs.rs/futures/0.3.19/futures/future/type.LocalBoxFuture.html
+//! - `#[async_recursion]` modifies your function to return a boxed [`Future`] with a [`Send`] bound.
+//! - `#[async_recursion(?Send)]` modifies your function to return a boxed [`Future`] _without_ a [`Send`] bound.
+//! - `#[async_recursion(Sync)]` modifies your function to return a boxed [`Future`] with [`Send`] and [`Sync`] bounds.
 //!
 //! ### License
 //!

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -22,30 +22,74 @@ impl Parse for AsyncItem {
 
 pub struct RecursionArgs {
     pub send_bound: bool,
-}
-
-impl Default for RecursionArgs {
-    fn default() -> Self {
-        RecursionArgs { send_bound: true }
-    }
+    pub sync_bound: bool,
 }
 
 /// Custom keywords for parser
 mod kw {
     syn::custom_keyword!(Send);
+    syn::custom_keyword!(Sync);
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Arg {
+    NotSend,
+    Sync,
+}
+
+impl std::fmt::Display for Arg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotSend => write!(f, "?Send"),
+            Self::Sync => write!(f, "Sync"),
+        }
+    }
+}
+
+impl Parse for Arg {
+    fn parse(input: ParseStream) -> Result<Self> {
+        if input.peek(Token![?]) {
+            input.parse::<Question>()?;
+            input.parse::<kw::Send>()?;
+            Ok(Arg::NotSend)
+        } else {
+            input.parse::<kw::Sync>()?;
+            Ok(Arg::Sync)
+        }
+    }
 }
 
 impl Parse for RecursionArgs {
     fn parse(input: ParseStream) -> Result<Self> {
-        // Check for the `?Send` option
-        if input.peek(Token![?]) {
-            input.parse::<Question>()?;
-            input.parse::<kw::Send>()?;
-            Ok(Self { send_bound: false })
-        } else if !input.is_empty() {
-            Err(input.error("expected `?Send` or empty"))
-        } else {
-            Ok(Self::default())
+        let mut send_bound: bool = true;
+        let mut sync_bound: bool = false;
+
+        let args_parsed: Vec<Arg> =
+            syn::punctuated::Punctuated::<Arg, syn::Token![,]>::parse_terminated(input)
+                .map_err(|e| input.error(format!("failed to parse macro arguments: {e}")))?
+                .into_iter()
+                .collect();
+
+        // Avoid sloppy input
+        if args_parsed.len() > 2 {
+            return Err(Error::new(Span::call_site(), "received too many arguments"));
+        } else if args_parsed.len() == 2 && args_parsed[0] == args_parsed[1] {
+            return Err(Error::new(
+                Span::call_site(),
+                format!("received duplicate argument: `{}`", args_parsed[0]),
+            ));
         }
+
+        for arg in args_parsed {
+            match arg {
+                Arg::NotSend => send_bound = false,
+                Arg::Sync => sync_bound = true,
+            }
+        }
+
+        Ok(Self {
+            send_bound,
+            sync_bound,
+        })
     }
 }

--- a/tests/args_sync.rs
+++ b/tests/args_sync.rs
@@ -1,0 +1,11 @@
+use async_recursion::async_recursion;
+
+#[async_recursion(Sync)]
+async fn send_and_sync() {}
+
+fn assert_is_send_and_sync(_: impl Send + Sync) {}
+
+#[test]
+fn test_sync_argument() {
+    assert_is_send_and_sync(send_and_sync());
+}

--- a/tests/expand/args_not_send.expanded.rs
+++ b/tests/expand/args_not_send.expanded.rs
@@ -1,0 +1,5 @@
+use async_recursion::async_recursion;
+#[must_use]
+fn no_send_bound() -> ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()>>> {
+    Box::pin(async move {})
+}

--- a/tests/expand/args_not_send.rs
+++ b/tests/expand/args_not_send.rs
@@ -1,0 +1,4 @@
+use async_recursion::async_recursion;
+
+#[async_recursion(?Send)]
+async fn no_send_bound() {}

--- a/tests/expand/args_punctuated.expanded.rs
+++ b/tests/expand/args_punctuated.expanded.rs
@@ -1,0 +1,25 @@
+use async_recursion::async_recursion;
+#[must_use]
+fn not_send_sync_1() -> ::core::pin::Pin<
+    Box<dyn ::core::future::Future<Output = ()> + ::core::marker::Sync>,
+> {
+    Box::pin(async move {})
+}
+#[must_use]
+fn not_send_sync_2() -> ::core::pin::Pin<
+    Box<dyn ::core::future::Future<Output = ()> + ::core::marker::Sync>,
+> {
+    Box::pin(async move {})
+}
+#[must_use]
+fn sync_not_send_1() -> ::core::pin::Pin<
+    Box<dyn ::core::future::Future<Output = ()> + ::core::marker::Sync>,
+> {
+    Box::pin(async move {})
+}
+#[must_use]
+fn sync_not_send_2() -> ::core::pin::Pin<
+    Box<dyn ::core::future::Future<Output = ()> + ::core::marker::Sync>,
+> {
+    Box::pin(async move {})
+}

--- a/tests/expand/args_punctuated.rs
+++ b/tests/expand/args_punctuated.rs
@@ -1,0 +1,13 @@
+use async_recursion::async_recursion;
+
+#[async_recursion(?Send, Sync)]
+async fn not_send_sync_1() {}
+
+#[async_recursion(?Send,Sync)]
+async fn not_send_sync_2() {}
+
+#[async_recursion(Sync, ?Send)]
+async fn sync_not_send_1() {}
+
+#[async_recursion(Sync,?Send)]
+async fn sync_not_send_2() {}

--- a/tests/expand/args_sync.expanded.rs
+++ b/tests/expand/args_sync.expanded.rs
@@ -1,0 +1,11 @@
+use async_recursion::async_recursion;
+#[must_use]
+fn sync() -> ::core::pin::Pin<
+    Box<
+        dyn ::core::future::Future<
+            Output = (),
+        > + ::core::marker::Send + ::core::marker::Sync,
+    >,
+> {
+    Box::pin(async move {})
+}

--- a/tests/expand/args_sync.rs
+++ b/tests/expand/args_sync.rs
@@ -1,0 +1,4 @@
+use async_recursion::async_recursion;
+
+#[async_recursion(Sync)]
+async fn sync() {}

--- a/tests/expand/lifetimes_explicit_async_recursion_bound.expanded.rs
+++ b/tests/expand/lifetimes_explicit_async_recursion_bound.expanded.rs
@@ -1,0 +1,19 @@
+use async_recursion::async_recursion;
+#[must_use]
+fn explicit_async_recursion_bound<'life0, 'life1, 'async_recursion>(
+    t: &'life0 T,
+    p: &'life1 [String],
+    prefix: Option<&'async_recursion [u8]>,
+    layer: Option<&'async_recursion [u8]>,
+) -> ::core::pin::Pin<
+    Box<
+        dyn ::core::future::Future<Output = ()> + 'async_recursion + ::core::marker::Send,
+    >,
+>
+where
+    'life0: 'async_recursion,
+    'life1: 'async_recursion,
+    'async_recursion: 'async_recursion,
+{
+    Box::pin(async move {})
+}

--- a/tests/expand/lifetimes_explicit_async_recursion_bound.rs
+++ b/tests/expand/lifetimes_explicit_async_recursion_bound.rs
@@ -1,0 +1,12 @@
+// Test that an explicit `async_recursion bound is left alone.
+// This is a workaround many
+use async_recursion::async_recursion;
+
+
+#[async_recursion]
+async fn explicit_async_recursion_bound(
+    t: &T,
+    p: &[String],
+    prefix: Option<&'async_recursion [u8]>,
+    layer: Option<&'async_recursion [u8]>,
+) {}

--- a/tests/lifetimes.rs
+++ b/tests/lifetimes.rs
@@ -41,6 +41,9 @@ async fn count_down(foo: Option<&str>) -> i32 {
     0
 }
 
+#[async_recursion]
+async fn explicit_async_recursion_bound(_: Option<&'async_recursion String>) {}
+
 #[test]
 fn lifetime_expansion_works() {
     block_on(async move {
@@ -73,5 +76,6 @@ fn lifetime_expansion_works() {
         assert_eq!(contains_value_2(&12, &node).await, false);
 
         count_down(None).await;
+        explicit_async_recursion_bound(None).await;
     });
 }

--- a/tests/ui/arg_not_sync.rs
+++ b/tests/ui/arg_not_sync.rs
@@ -1,0 +1,15 @@
+use async_recursion::async_recursion;
+
+fn assert_is_sync(_: impl Sync) {}
+
+
+#[async_recursion]
+async fn send_not_sync() {}
+
+#[async_recursion(?Send)]
+async fn not_send_not_sync() {}
+
+fn main() {
+    assert_is_sync(send_not_sync());
+    assert_is_sync(not_send_not_sync());
+}

--- a/tests/ui/arg_not_sync.stderr
+++ b/tests/ui/arg_not_sync.stderr
@@ -1,0 +1,51 @@
+error[E0277]: `dyn Future<Output = ()> + Send` cannot be shared between threads safely
+  --> tests/ui/arg_not_sync.rs:13:20
+   |
+13 |     assert_is_sync(send_not_sync());
+   |     -------------- ^^^^^^^^^^^^^^^ `dyn Future<Output = ()> + Send` cannot be shared between threads safely
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Sync` is not implemented for `dyn Future<Output = ()> + Send`
+   = note: required for `Unique<dyn Future<Output = ()> + Send>` to implement `Sync`
+note: required because it appears within the type `Box<dyn Future<Output = ()> + Send>`
+  --> $RUST/alloc/src/boxed.rs
+   |
+   | pub struct Box<
+   |            ^^^
+note: required because it appears within the type `Pin<Box<dyn Future<Output = ()> + Send>>`
+  --> $RUST/core/src/pin.rs
+   |
+   | pub struct Pin<P> {
+   |            ^^^
+note: required by a bound in `assert_is_sync`
+  --> tests/ui/arg_not_sync.rs:3:27
+   |
+3  | fn assert_is_sync(_: impl Sync) {}
+   |                           ^^^^ required by this bound in `assert_is_sync`
+
+error[E0277]: `dyn Future<Output = ()>` cannot be shared between threads safely
+  --> tests/ui/arg_not_sync.rs:14:20
+   |
+14 |     assert_is_sync(not_send_not_sync());
+   |     -------------- ^^^^^^^^^^^^^^^^^^^ `dyn Future<Output = ()>` cannot be shared between threads safely
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Sync` is not implemented for `dyn Future<Output = ()>`
+   = note: required for `Unique<dyn Future<Output = ()>>` to implement `Sync`
+note: required because it appears within the type `Box<dyn Future<Output = ()>>`
+  --> $RUST/alloc/src/boxed.rs
+   |
+   | pub struct Box<
+   |            ^^^
+note: required because it appears within the type `Pin<Box<dyn Future<Output = ()>>>`
+  --> $RUST/core/src/pin.rs
+   |
+   | pub struct Pin<P> {
+   |            ^^^
+note: required by a bound in `assert_is_sync`
+  --> tests/ui/arg_not_sync.rs:3:27
+   |
+3  | fn assert_is_sync(_: impl Sync) {}
+   |                           ^^^^ required by this bound in `assert_is_sync`

--- a/tests/ui/args_invalid.rs
+++ b/tests/ui/args_invalid.rs
@@ -1,0 +1,14 @@
+use async_recursion::async_recursion;
+
+#[async_recursion(?Sync)]
+async fn not_sync() {}
+
+#[async_recursion(Sync Sync)]
+async fn not_punctuated() {}
+
+#[async_recursion(Sync?Send)]
+async fn what_even_is_this() {}
+
+
+
+fn main() {}

--- a/tests/ui/args_invalid.stderr
+++ b/tests/ui/args_invalid.stderr
@@ -1,0 +1,17 @@
+error: failed to parse macro arguments: expected `Send`
+ --> tests/ui/args_invalid.rs:3:20
+  |
+3 | #[async_recursion(?Sync)]
+  |                    ^^^^
+
+error: failed to parse macro arguments: expected `,`
+ --> tests/ui/args_invalid.rs:6:24
+  |
+6 | #[async_recursion(Sync Sync)]
+  |                        ^^^^
+
+error: failed to parse macro arguments: expected `,`
+ --> tests/ui/args_invalid.rs:9:23
+  |
+9 | #[async_recursion(Sync?Send)]
+  |                       ^

--- a/tests/ui/args_repeated.rs
+++ b/tests/ui/args_repeated.rs
@@ -1,0 +1,12 @@
+use async_recursion::async_recursion;
+
+#[async_recursion(?Send, ?Send)]
+async fn repeated_args_1() {}
+
+#[async_recursion(?Send, Sync, ?Send)]
+async fn repeated_args_2() {}
+
+#[async_recursion(Sync, ?Send, Sync, ?Send)]
+async fn repeated_args_3() {}
+
+fn main() {}

--- a/tests/ui/args_repeated.stderr
+++ b/tests/ui/args_repeated.stderr
@@ -1,0 +1,23 @@
+error: received duplicate argument: `?Send`
+ --> tests/ui/args_repeated.rs:3:1
+  |
+3 | #[async_recursion(?Send, ?Send)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `async_recursion` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: received too many arguments
+ --> tests/ui/args_repeated.rs:6:1
+  |
+6 | #[async_recursion(?Send, Sync, ?Send)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `async_recursion` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: received too many arguments
+ --> tests/ui/args_repeated.rs:9:1
+  |
+9 | #[async_recursion(Sync, ?Send, Sync, ?Send)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `async_recursion` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This allows a `Sync` bound to be included on the future returned by the modified function:

```rust
#[async_recursion(Sync)]
async fn returned_future_is_send_and_sync() {}
```

As mentioned in [this comment](https://github.com/dtolnay/async-trait/issues/77#issue-589657525), a `Sync` bound on a `Future` is useless, since you can't _do_ anything with a `&Future`.  That being said, you may still want to store the resulting future in a struct, and you might want that struct to be `Sync`, so there are use-cases here.

Given that this is something that most people shouldn't need (nor use!), a `Sync` bound is not included by default.