### PR TITLE
Fix incorrect syn features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = { version = "1.0", default-features = false }
 quote = { version = "1.0", default-features = false }
-syn = { version = "2.0", features = ["full", "visit-mut"],  default-features = false }
+syn = { version = "2.0", features = ["full", "visit-mut", "parsing", "printing", "proc-macro", "clone-impls"],  default-features = false }
 
 [dev-dependencies]
 futures-executor = "0.3"


### PR DESCRIPTION
The version 1 resolver (currently in use) unifies features across normal and dev dependencies; the dev dependencies here are enabling features that are actually required for the macro to function. Ensure all these features are enabled up-front.

Fixes #43 
